### PR TITLE
ci: bump actions/checkout to v7 and wrangler-action to v4

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Wrangler deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         env:
           ENVIRONMENT: ${{ github.event.pull_request.base.ref == 'master' && 'production' || 'development' }}
         with:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -29,7 +29,7 @@ jobs:
     if: github.event.action != 'closed' || github.event.pull_request.merged != true
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -43,7 +43,7 @@ jobs:
     if: github.event.action != 'closed' || github.event.pull_request.merged != true
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary
`.github/workflows/*.yaml` の action pin を更新：
- `actions/checkout`: `v5` → `v7`
- `cloudflare/wrangler-action`: `v3` → `v4`（wrangler v4 系に追従）

`oven-sh/setup-bun@v2` は最新メジャーに一致してるため据え置き。

## Notes
- `wrangler-action@v4` は wrangler v4 に合わせた挙動変更が入ってるので、まず develop（開発環境デプロイ）で動作確認してから master に上げるべし。
- ローカル生成物 (`src/generated/`) や既存の env / secrets 側には触ってません。

## Test plan
- [ ] Integration workflow が緑
- [ ] develop マージ後の Cloudflare 開発デプロイが成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)