### PR TITLE
chore(commitlint): raise header-max-length limit to 128

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,3 +1,5 @@
 ---
 extends:
   - '@commitlint/config-conventional'
+rules:
+  header-max-length: [2, always, 128]


### PR DESCRIPTION
## What

Override `header-max-length` in `.commitlintrc.yaml` from the default `100` to `128`.

## Why

Author-side, the `commit-push-pr` skill still tells the agent to keep commit headers under **100** characters so titles stay readable in `git log --oneline` and GitHub's PR list. Bumping the validator to **128** just gives a safety margin — if a title creeps a few characters over 100, the pre-commit hook stops nagging instead of blocking the commit outright. Hard ceiling stays close enough to the readable limit that nothing truly runaway can slip through.

## Test plan

- [x] 128-char header → `commitlint` passes (`exit=0`).
- [x] 129-char header → `commitlint` fails with `header must not be longer than 128 characters` (`exit=1`).

No version bump — pure config change with no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)