### PR TITLE
fix(schema): auto-refresh Schedule.updated_at on upsert

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thunder_api",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "SplatNet3から取得したJSONをパースしてSplatNet2形式などの扱いやすいフォーマットに変換してくれるAPIです",
   "author": "@tkgstrator",
   "private": true,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,7 +23,7 @@ model Schedule {
   stageId     Int      @map("stage_id")
   rareWeapons String   @map("rare_weapons")
   weaponList  String   @map("weapon_list")
-  updatedAt   DateTime @default(now()) @map("updated_at")
+  updatedAt   DateTime @default(now()) @updatedAt @map("updated_at")
 
   @@index([startTime(sort: Desc)], map: "idx_schedules_start_time")
   @@map("schedules")


### PR DESCRIPTION
## Summary

- Add `@updatedAt` to `Schedule.updated_at` so the field advances on every UPDATE, not only on INSERT via `@default(now())`.
- Purely client-side directive — no DDL change, no D1 migration required (verified via `prisma migrate diff`: generated SQL is identical to `migrations/0001_init.sql`).

## Verification

Executed against production D1 via `wrangler dev --remote --test-scheduled --env production`:

- BEFORE: `MAX(updated_at)` = `2026-07-14T22:30:09.030Z`
- FIRE: `GET /__scheduled?cron=*/30+*+*+*+*` → `200 OK`, `Ran scheduled event`
- AFTER: `MAX(updated_at)` = `2026-07-14T22:42:53.209Z`

Previously the timestamp stayed frozen across cron ticks because upserts touched only the payload columns.

## Test plan

- [ ] Merge triggers `deployment.yaml` → wrangler deploy to `av5ja-development`
- [ ] Wait for a `*/30` cron tick and confirm `MAX(updated_at)` on dev D1 advances
