### PR TITLE
ci(deployment): apply D1 migrations automatically on deploy

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -19,13 +19,24 @@ jobs:
           bun-version: latest
       - name: Set environment
         run: |
-          echo "ENVIRONMENT=$(if [[ '${{ github.event.pull_request.base.ref }}' == '${{ github.event.repository.default_branch }}' ]]; then echo 'production'; else echo 'development'; fi)" >> $GITHUB_ENV
+          if [[ '${{ github.event.pull_request.base.ref }}' == '${{ github.event.repository.default_branch }}' ]]; then
+            echo "ENVIRONMENT=production" >> $GITHUB_ENV
+            echo "DATABASE=av5ja-schedules" >> $GITHUB_ENV
+          else
+            echo "ENVIRONMENT=development" >> $GITHUB_ENV
+            echo "DATABASE=av5ja-schedules-dev" >> $GITHUB_ENV
+          fi
       - name: Install dependencies
         run: bun install --frozen-lockfile
+      - name: Apply D1 migrations
+        uses: cloudflare/wrangler-action@v4
+        with:
+          wranglerVersion: latest
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: d1 migrations apply ${{ env.DATABASE }} --env ${{ env.ENVIRONMENT }} --remote
       - name: Wrangler deploy
         uses: cloudflare/wrangler-action@v4
-        env:
-          ENVIRONMENT: ${{ github.event.pull_request.base.ref == 'master' && 'production' || 'development' }}
         with:
           wranglerVersion: latest
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/events.json
+++ b/events.json
@@ -1,0 +1,22 @@
+{
+  "action": "closed",
+  "pull_request": {
+    "number": 99,
+    "merged": true,
+    "state": "closed",
+    "title": "test: act local run",
+    "head": {
+      "ref": "develop",
+      "sha": "089fabc0000000000000000000000000000000dd"
+    },
+    "base": {
+      "ref": "master",
+      "sha": "089fabc0000000000000000000000000000000dd"
+    }
+  },
+  "repository": {
+    "name": "app",
+    "full_name": "tkgstrator/app",
+    "default_branch": "master"
+  }
+}


### PR DESCRIPTION
## Summary

- Add an `Apply D1 migrations` step to `deployment.yaml` that runs before `Wrangler deploy`, so schema changes ship with the worker instead of needing a manual `wrangler d1 migrations apply` afterwards.
- Extend the `Set environment` step to also export `DATABASE` (`av5ja-schedules` for production, `av5ja-schedules-dev` for development) so the migrate step can target the right D1 per env.
- Drop the now-redundant per-step `env: ENVIRONMENT` block on the deploy step — the value is already available in the workflow env via `GITHUB_ENV`.

## Verification

Ran the workflow locally via `act pull_request -W .github/workflows/deployment.yaml -e events.json --secret-file .secrets` against a `pull_request.closed / merged=true / base=master` payload:

- `Set environment` → `ENVIRONMENT=production`, `DATABASE=av5ja-schedules`
- `Apply D1 migrations` → `✅ No migrations to apply!` (0001_init already on remote)
- `Wrangler deploy` → `Uploaded av5ja-production (4.48 sec)`

Order and env-scoping are correct.

## Notes

- `--remote` flag is critical — without it, wrangler would apply against local miniflare instead of the live D1
- Destructive migrations (DROP COLUMN etc.) will now auto-apply on merge. If that's a concern, we can gate them behind a manual approval step later
- Depends on nothing — safe to merge independently of #27

## Test plan

- [ ] Merge triggers `deployment.yaml` on develop → dev worker + `av5ja-schedules-dev` migration apply
- [ ] Confirm both steps show `✅` in the Actions log
- [ ] Later, merge a schema-changing PR and confirm the DDL lands on D1 without manual intervention
