### PR TITLE
chore(wrangler): pin account_id to avoid CI env drift

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,6 @@
 name = "av5ja-api"
 main = "src/index.ts"
+account_id = "2488ea57494b2dacae95a6e363e7dcb2"
 compatibility_flags = ["nodejs_compat"]
 compatibility_date = "2024-09-02"
 send_metrics = true


### PR DESCRIPTION
## What

Hardcode the Yuki Minakami Cloudflare `account_id` (`2488ea57494b2dacae95a6e363e7dcb2`) at the top of `wrangler.toml`.

## Why

The deploy workflow (`deployment.yaml`) fell over on `wrangler d1 migrations apply --remote` with `Authentication error [code: 10000]` / `Invalid access token [code: 9109]`. The `CLOUDFLARE_API_TOKEN` itself is valid (verified locally via `wrangler whoami` → Yuki Minakami), and now has `D1 Write` + `Workers Scripts Write`, so the remaining risk was `CLOUDFLARE_ACCOUNT_ID` drifting from what the token is scoped to. Pinning the ID in `wrangler.toml` removes that variable entirely — wrangler resolves the same account regardless of what env var the runner passes.

## Test plan

- [ ] Merge into `develop` → `deployment.yaml` runs against `av5ja-schedules-staging` D1
- [ ] `Apply D1 migrations` step shows `✅` (either `No migrations to apply!` or the DDL applies)
- [ ] `Wrangler deploy` step deploys `av5ja-api-staging` without auth error

## Notes

- No version bump — infra-only config change.
- Token permissions confirmed sufficient (D1 Write, Workers Scripts Write, Account Settings Read, scoped to entire Yuki Minakami account).
- `CLOUDFLARE_ACCOUNT_ID` GitHub secret can stay; it's now redundant but harmless (wrangler.toml wins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)