### PR TITLE
fix(schedules): return all rows instead of limiting to 50

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thunder_api",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "SplatNet3から取得したJSONをパースしてSplatNet2形式などの扱いやすいフォーマットに変換してくれるAPIです",
   "author": "@tkgstrator",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thunder_api",
-  "version": "7.0.3",
+  "version": "7.0.5",
   "description": "SplatNet3から取得したJSONをパースしてSplatNet2形式などの扱いやすいフォーマットに変換してくれるAPIです",
   "author": "@tkgstrator",
   "private": true,

--- a/src/api/schedules/index.ts
+++ b/src/api/schedules/index.ts
@@ -13,8 +13,7 @@ const EDGE_TTL_SECONDS = 1800
 const readFromD1 = async (env: Bindings): Promise<CoopSchedule.Response[]> => {
   const prisma = createPrismaClient(env)
   const rows = await prisma.schedule.findMany({
-    orderBy: { startTime: 'desc' },
-    take: 50
+    orderBy: { startTime: 'desc' }
   })
   return rows.map((row) =>
     CoopSchedule.Response.parse({


### PR DESCRIPTION
## What

Drop the hardcoded `take: 50` cap on `GET /v3/schedules` so the endpoint returns the full history from D1.

## Why

After the KV → D1 backfill loaded 858 historical schedules into the production `av5ja-schedules` table, the API still only returned the newest 50 rows — the endpoint's `findMany` had `take: 50` baked in. Externally this looked identical to "past schedules disappeared." Removing the cap restores the previous KV-era behavior of returning the whole set.

## Verification

- Before: `curl -s https://api.splatnet3.com/v3/schedules | jq '.schedules | length'` → 50
- After: should return 858 (or however many rows are in D1 at read time)

## Test plan

- [ ] Merge → staging deploy → `/v3/schedules` on staging returns > 50 rows
- [ ] Release to master → production `/v3/schedules` returns full history
- [ ] Response size stays well within worker limits (~215 KB for 858 rows)

## Notes

- Version bumped to `7.0.6` (patch — user-visible behavior fix).
- No schema change, no migration needed.
- Edge cache (Cache Rules) still holds the previous 50-row response for up to 30 min after deploy; purge `https://api.splatnet3.com/v3/schedules` if immediate confirmation is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)