### PR TITLE
chore: release v7.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thunder_api",
-  "version": "7.0.3",
+  "version": "7.0.6",
   "description": "SplatNet3から取得したJSONをパースしてSplatNet2形式などの扱いやすいフォーマットに変換してくれるAPIです",
   "author": "@tkgstrator",
   "private": true,

--- a/src/api/schedules/index.ts
+++ b/src/api/schedules/index.ts
@@ -13,8 +13,7 @@ const EDGE_TTL_SECONDS = 1800
 const readFromD1 = async (env: Bindings): Promise<CoopSchedule.Response[]> => {
   const prisma = createPrismaClient(env)
   const rows = await prisma.schedule.findMany({
-    orderBy: { startTime: 'desc' },
-    take: 50
+    orderBy: { startTime: 'desc' }
   })
   return rows.map((row) =>
     CoopSchedule.Response.parse({


### PR DESCRIPTION
## Release v7.0.6

Hotfix promoting the schedules-limit fix to production.

## What's shipping

- `fix(schedules): return all rows instead of limiting to 50` (#33)

## Production impact

- `GET /v3/schedules` will return the full history (currently 858 rows) instead of the newest 50.
- Response size ~215 KB — well within Cloudflare Workers response limits.
- Edge cache still holds the previous 50-row response for up to 30 min; purge required for immediate confirmation.

## Test plan

- [ ] Production deploy succeeds
- [ ] After edge purge, `curl https://api.splatnet3.com/v3/schedules | jq '.schedules | length'` returns 858+

🤖 Generated with [Claude Code](https://claude.com/claude-code)